### PR TITLE
Initial setup for automatic helm chart generation on release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - created
+  workflow_dispatch: # This allows the workflow to be triggered manually
 
 jobs:
   release:


### PR DESCRIPTION
Added workflow to make the repository into a helm chart repository. 

The workflow is set up to run on each release and generate the relevant pages for the new version of each chart.

This will allow simply adding the repository to helm by running:

 `helm repo add tng-key-distribution https://worldhealthorganization.github.io/tng-key-distribution --username "${GITHUB_TOKEN}"  --password "${GITHUB_TOKEN}" ` 
 
 Installing the desired **chart:version** can be done by simply running 
 
 `helm install tng-key-distribution/tngkds-backend:1.6.0` 

As this is a private repository, adding a github token to the requests will be required both locally and while using in a workflow. Public access to only the chart repository (not the code itself) can be enabled [here](https://github.com/WorldHealthOrganization/tng-key-distribution/settings/pages) if necessary for testing.

The workflow is using the official helm [chart-releaser-action](https://github.com/helm/chart-releaser-action) and GitHub pages to release the chart. The branch `gh-pages` is required for this to work.

