### PR TITLE
Feat: Update DDCC-Lib (+ Update to Java 21)

### DIFF
--- a/.github/workflows/ci-dependency-check.yml
+++ b/.github/workflows/ci-dependency-check.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: adopt
       - uses: actions/checkout@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The TNG Key Distribution Service is part of the national backends of the partici
 
 ### Prerequisites
 
-- [Open JDK 17](https://openjdk.java.net)
+- [Open JDK 21](https://openjdk.java.net)
 - [Maven](https://maven.apache.org)
 - [Docker](https://www.docker.com)
 - An installation of the [TNG](https://github.com/worldhealthorganization/smart-trust-network-gateway)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-starter-parent</artifactId>
-        <version>2023.0.1</version>
+        <version>2023.0.2</version>
     </parent>
 
     <groupId>tng.trustnetwork.keydistribution</groupId>
@@ -24,9 +24,9 @@
 
     <properties>
         <!-- java -->
-        <java.version>17</java.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>21</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <!-- charset -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>eu.europa.ec.dgc</groupId>
             <artifactId>ddcc-gateway-lib</artifactId>
-            <version>2.0.2</version>
+            <version>2.1.0</version>
         </dependency>
         <!-- Spring Boot Dependencies -->
         <dependency>


### PR DESCRIPTION
Depends on https://github.com/WorldHealthOrganization/ddcc-gateway-lib/pull/16