### PR TITLE
feat: Helm chart upgrades

### DIFF
--- a/k8s/helm/tngkds/Chart.yaml
+++ b/k8s/helm/tngkds/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/helm/tngkds/charts/tngkds-backend/Chart.yaml
+++ b/k8s/helm/tngkds/charts/tngkds-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/helm/tngkds/charts/tngkds-postgres/Chart.yaml
+++ b/k8s/helm/tngkds/charts/tngkds-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/k8s/helm/tngkds/templates/did-signer-secret.yaml
+++ b/k8s/helm/tngkds/templates/did-signer-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: did-signer-secret
+  namespace: {{ .Release.Namespace }}
+data:
+	did-signer.p12: {{ .Values.secrets.didSigner }}
+type: Opaque

--- a/k8s/helm/tngkds/templates/mtls-secret.yaml
+++ b/k8s/helm/tngkds/templates/mtls-secret.yaml
@@ -1,0 +1,10 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mtls-secret
+  namespace: {{ .Release.Namespace }}
+data:
+	tls_key_store.p12: {{ .Values.secrets.mtls.tlsKeyStore }}
+  tng_tls_server_truststore.p12: {{ .Values.secrets.mtls.tlsServerTrustStore }}
+	trustanchor_store.jks: {{ .Values.secrets.mtls.tlsTrustAnchorStore }}
+type: Opaque

--- a/k8s/helm/tngkds/templates/tng-distribution-pull-secret.yaml
+++ b/k8s/helm/tngkds/templates/tng-distribution-pull-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: tng-distribution-pull-secret
+  namespace: {{ .Release.Namespace }}
+data:
+	.dockerconfigjson: {{ .Values.secrets.dockerPull }}
+type: kubernetes.io/dockerconfigjson

--- a/k8s/helm/tngkds/templates/truststore-secret.yaml
+++ b/k8s/helm/tngkds/templates/truststore-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: truststore-secret
+  namespace: {{ .Release.Namespace }}
+data:
+	tls_trust_store.jks: {{ .Values.secrets.trustStore }}
+type: Opaque

--- a/k8s/helm/tngkds/values.yaml
+++ b/k8s/helm/tngkds/values.yaml
@@ -41,3 +41,11 @@ tngkds-backend:
         alias: trustanchor
         password: <password of trustanchor_store>
         path: /certs/trustanchor_store.jks
+  secrets: # Below are all b64 encoded
+	  didSigner: <DID signer cert>
+	  dockerPull: <docker pull secret>
+	  trustStore: <trust store jks>
+	  mtls:
+		  tlsKeyStore: <tls trust store>
+		  tlsServerTrustStore: <tls server trust store>
+		  tlsTrustAnchorStore: <tls trustanchor store>


### PR DESCRIPTION
In preparation for automated deployment of the chart from the tng-iac repository, the following updates have been made to the helm charts:

Added following secrets to the tngkds chart:

- tng-distribution-pull-secret
- truststore-secret
- mtls-secret
- did-signer-secret

The necessary values for the secrets can be defined in the values.yaml under `.tngkds-backend.secrets`

Incremented the version of the main tngkds chart and the sub-charts as well so the workflow creates a new release for them.