### PR TITLE
feat: bump up version of ddcc-gateway-lib to support DESC & DECA export

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>eu.europa.ec.dgc</groupId>
             <artifactId>ddcc-gateway-lib</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
         <!-- Spring Boot Dependencies -->
         <dependency>


### PR DESCRIPTION
[WHOGDHCN-806](https://strive.devops.t-systems.net/jira/browse/WHOGDHCN-806) - Prepare KDS to export DECA and DESC type certs to GitHub