### PR TITLE
fix: added suppression for CVE-2025-49124

### DIFF
--- a/.github/workflows/ci-dependency-check.yml
+++ b/.github/workflows/ci-dependency-check.yml
@@ -11,14 +11,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: adopt
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -11,8 +11,9 @@
     <cve>CVE-2012-5055</cve>
   </suppress>
   <suppress>
-    <notes>see https://tomcat.apache.org/security-9.html#Apache_Tomcat_9.x_vulnerabilities vulnerability is fixed in tomcat 9.0.38</notes>
+    <notes>see https://tomcat.apache.org/security-9.html#Apache_Tomcat_9.x_vulnerabilities vulnerability is fixed in tomcat 9.0.38, CVE-2025-49124 affects only windows and icacls.exe not used here.</notes>
     <cve>CVE-2020-13943</cve>
+      <cve>CVE-2025-49124</cve>
   </suppress>
   <suppress>
     <!-- spring-boot and spring are excluded from cfenv artifact. Related issues can be omitted. -->

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.1.3</version>
+                <version>12.1.6</version>
                 <configuration>
                     <suppressionFile>./owasp/suppressions.xml</suppressionFile>
                     <failBuildOnCVSS>8</failBuildOnCVSS>


### PR DESCRIPTION
Suppressed CVE-2025-49124 since it relates to windows binary not used